### PR TITLE
Add max_path_depth and show_line_number option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,6 +28,21 @@ Installation
       gem "view_inspect"
     end
 
+Configuration
+----
+    # config/environments/development.rb
+    ViewInspect.show_line_number = true # default value true
+
+    ViewInspect.max_path_depth = 3 
+    #   default value 0, 0 means show full path, when a positive number is given 
+    # and the positive number is less than absolute path depth of the view file, 
+    # then the in view, the path will be display in relative:
+    #   Example if a view path is /foo/bar/project/app/views/users/index.html.erb, 
+    # if you set max_path_depth to 3 then the output will be 
+    # views/users/index.html.erb, so you can easily copy 
+    # the search input of your editor by double click select it
+
+
 Warning
 ----
 

--- a/lib/view_inspect.rb
+++ b/lib/view_inspect.rb
@@ -6,6 +6,7 @@ module ViewInspect
   def self.init
     return unless allow_view_source_location?
 
+    @show_line_number = true
     ServerSideTemplate.handle
     ClientSideTemplate.handle
   end
@@ -16,6 +17,22 @@ module ViewInspect
 
   def self.disable=(bool)
     @disable = bool
+  end
+
+  def self.max_path_depth=(depth)
+    @max_path_depth = depth
+  end
+
+  def self.max_path_depth
+    @max_path_depth && @max_path_depth >= 0 ? @max_path_depth : 0
+  end
+
+  def self.show_line_number?
+    @show_line_number
+  end
+
+  def self.show_line_number=(bool)
+    @show_line_number = bool
   end
 
   def self.show_html_syntax_error?

--- a/lib/view_inspect/handlers/html_template.rb
+++ b/lib/view_inspect/handlers/html_template.rb
@@ -31,8 +31,9 @@ module ViewInspect
 
         doc.traverse do |node|
           if node.is_a?(::Nokogiri::XML::Element)
-            file_line = [filepath, node.line].join(":")
-            node.set_attribute "data-orig-file-line", file_line
+            file_line = [filepath.split(File::SEPARATOR)[-ViewInspect.max_path_depth..-1].join(File::SEPARATOR)]
+            file_line << node.line if ViewInspect.show_line_number?
+            node.set_attribute "data-orig-file-line".freeze, file_line.join(':'.freeze)
           end
         end
 


### PR DESCRIPTION
Add two configure option: `show_line_number` and `max_path_depth`
Why?
  when I use ViewInspect, I usually need double click  attribute `data-orig-file-line` 's value and copy it to search in my editor(sublime text3),  but sublime can not recognize absolute path and path with file number